### PR TITLE
adding options to disable ssl checks that didn't work when building;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/centos/centos:centos7
 COPY entrypoint.sh /
 
 RUN yum install -y wget sysvinit-tools net-tools iproute && \
-    wget https://support.arraynetworks.net/prx/001/http/supportportal.arraynetworks.net/downloads/pkg_9_4_0_385/MP_Linux_1.2.9/MotionPro_Linux_CentOS_x64_build-8.sh && \
+    wget --no-check-certificate https://support.arraynetworks.net/prx/001/http/supportportal.arraynetworks.net/downloads/pkg_9_4_0_385/MP_Linux_1.2.9/MotionPro_Linux_CentOS_x64_build-8.sh && \
     chmod +x MotionPro_Linux_CentOS_x64_build-8.sh && \
     ./MotionPro_Linux_CentOS_x64_build-8.sh
 


### PR DESCRIPTION
I don't like this; but I had to do this to get the build to work on Fedora Silverblue 33. 